### PR TITLE
fix: Bumped version of dotnet SDK to 6.0.x in .github/workflows/release.yml

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -124,7 +124,7 @@ jobs:
       fail-fast: true
       matrix:
         dotnetversion:
-          - 3.1.301
+          - 6.0.x
         goversion:
           - 1.20.x
         language:


### PR DESCRIPTION
* Bumped version of dotnet SDK to 6.0.x in .github/workflows/release.yml