### PR TITLE
Point to Go docs site to fix a 404 link

### DIFF
--- a/docs/installation-configuration.md
+++ b/docs/installation-configuration.md
@@ -10,7 +10,7 @@ The Pulumi MSSQL provider is available as a package in all Pulumi languages:
 
 * JavaScript/TypeScript: [`@pulumiverse/mssql`](https://www.npmjs.com/package/@pulumiverse/mssql)
 * Python: [`pulumiverse_mssql`](https://pypi.org/project/pulumiverse_mssql/)
-* Go: [`github.com/pulumiverse/pulumi-mssql/sdk/go/mssql`](https://github.com/pulumiverse/pulumi-mssql/sdk/go/mssql)
+* Go: [`github.com/pulumiverse/pulumi-mssql/sdk/go/mssql`](https://pkg.go.dev/github.com/pulumiverse/pulumi-mssql/sdk/go/mssql)
 * .NET: [`Pulumiverse.Mssql`](https://www.nuget.org/packages/Pulumiverse.Mssql)
 
 ### Provider Binary


### PR DESCRIPTION
Our website publishing detected a wrong link. Updating to point to the `pkg.go.dev` docs site for this package.

Please publish a new release after merging.